### PR TITLE
adjusted map without media query

### DIFF
--- a/client/src/pages/Overworld/style.css
+++ b/client/src/pages/Overworld/style.css
@@ -1,6 +1,7 @@
 .leaflet-container {
     width: 100%;
     height: 100vh;
+    margin-top: 64px;
 }
 
 .levelTitle {


### PR DESCRIPTION
App bar is actually the same # of pixels on every viewport, so I just set the top margin to be the height of app bar